### PR TITLE
Fix bug in parsing hex char escapes

### DIFF
--- a/tests/test_parsing/test_parsing.py
+++ b/tests/test_parsing/test_parsing.py
@@ -138,6 +138,29 @@ class Test(TestCase):
         self.assertEqual(3, len(outbuf), f"len(outbuf): {len(outbuf)} != 3")
         self.assertListEqual([2, ord("你"), ord("你")], outbuf)
 
+        escaped_char_src = '"\\n"'
+        outbuf = []
+
+        remaining_src = _parse_rhs_literal_string(escaped_char_src, outbuf)
+        self.assertEqual(3, len(outbuf), f"len(outbuf): {len(outbuf)} != 3")
+        self.assertListEqual([2, ord("\n"), ord("\n")], outbuf)
+
+        escaped_backslash_src = '"\\\\"'
+        outbuf = []
+
+        remaining_src = _parse_rhs_literal_string(escaped_backslash_src, outbuf)
+        self.assertEqual(3, len(outbuf), f"len(outbuf): {len(outbuf)} != 3")
+        self.assertListEqual([2, ord("\\"), ord("\\")], outbuf)
+        self.assertEqual("", remaining_src, f"remaining_src: {remaining_src} != ''")
+
+        escaped_backslash_src = '"\\x5C"'
+        outbuf = []
+
+        remaining_src = _parse_rhs_literal_string(escaped_backslash_src, outbuf)
+        self.assertEqual(3, len(outbuf), f"len(outbuf): {len(outbuf)} != 3")
+        self.assertListEqual([2, ord("\\"), ord("\\")], outbuf)
+        self.assertEqual("", remaining_src, f"remaining_src: {remaining_src} != ''")
+
     def test_null(self):
         src = "root ::= "
         rhs_src = ""
@@ -289,6 +312,15 @@ class Test(TestCase):
 
         src = 'root ::= ("2" | "3" | "4") | ("5" | "6" | "7")'
         rhs_src = '("2" | "3" | "4") | ("5" | "6" | "7")'
+        state = ParseState()
+        state.symbol_table["root"] = 9
+        _ = parse_rhs(
+            state=state, rhs=rhs_src, rule_name="root", rule_id=9, is_nested=False
+        )
+        logging.debug(f"state.grammar_encoding of {rhs_src}: {state.grammar_encoding}")
+
+        src = 'root ::= "\\\\"'
+        rhs_src = '"\\\\"'
         state = ParseState()
         state.symbol_table["root"] = 9
         _ = parse_rhs(

--- a/tests/test_parsing/test_parsing.py
+++ b/tests/test_parsing/test_parsing.py
@@ -138,6 +138,8 @@ class Test(TestCase):
         self.assertEqual(3, len(outbuf), f"len(outbuf): {len(outbuf)} != 3")
         self.assertListEqual([2, ord("你"), ord("你")], outbuf)
 
+    
+    def test__parse_escape(self):
         escaped_char_src = '"\\n"'
         outbuf = []
 

--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -127,7 +127,7 @@ def parse_char(src) -> (str, str):
             if first > -1:
                 second = hex_to_int(src[3])
                 if second > -1:
-                    return (first << 4) + second, src[4:]
+                    return chr((first << 4) + second), src[4:]
             raise RuntimeError("expecting \\xNN at " + src)
         elif esc in ('"', "[", "]"):
             return esc, src[2:]


### PR DESCRIPTION
Bugfix: the parser would crash if it encountered `"\x5C"` in a grammar. This commit fixes that bug. (There is still a bug I couldn't locate that causes the parser to crash with `"\\"`. But the `"\x5C"` provides a workaround.)

The bug was that the parsing code returned an `int` instead of a `str`, as the client code expected.

This commit also adds some test cases I used to find the problem.