### PR TITLE
Update vocab_struct.py to fix llama3 tokenizer

### DIFF
--- a/transformers_cfg/tokenization/vocab_struct.py
+++ b/transformers_cfg/tokenization/vocab_struct.py
@@ -28,7 +28,8 @@ class TokenTrie:
             hex_value = match.group(1)
             return chr(int(hex_value, 16))
 
-        if "gpt2" in tokenizer.__class__.__name__.lower():
+        if ("gpt2" in tokenizer.__class__.__name__.lower() 
+            or "pretrained" in tokenizer.__class__.__name__.lower()): # llama3 tokenizer
             special = tokenizer.additional_special_tokens_ids
 
             # Here, the decoder does a string replace on a bunch of sequences


### PR DESCRIPTION
This fix is suggested by Yuxing. But we may need to see if this imply other bugs before merging it. Check `pretrained` in tokenizer class name will impact a broad range of tokenizers.