### PR TITLE
Add support for DeepSeek

### DIFF
--- a/tests/test_accept_token_sequence/test_deepseek.py
+++ b/tests/test_accept_token_sequence/test_deepseek.py
@@ -1,0 +1,17 @@
+import unittest
+
+from transformers import AutoTokenizer
+
+from tests.test_accept_token_sequence._test_accept_tokens_mixin import (
+    TokenizerTesterMixin,
+)
+
+
+# @unittest.skip("CodeGen is not supported and will be removed")
+class DeepSeekTokenizerTest(TokenizerTesterMixin, unittest.TestCase):
+
+    tokenizer_class = AutoTokenizer
+    pretrained_name = "deepseek-ai/deepseek-coder-1.3b-base"
+
+    def setUp(self):
+        super().setUp()

--- a/transformers_cfg/tokenization/byte_trie.py
+++ b/transformers_cfg/tokenization/byte_trie.py
@@ -1,6 +1,6 @@
 import logging
 from functools import lru_cache
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 from collections import deque
 
 from transformers_cfg.tokenization.middle.TokenizerMiddleMapping import (
@@ -54,9 +54,13 @@ class ByteTrie:
         mapping = TokenizerMiddleMapping.from_hf_tokenizer(tokenizer)
         TCFG_tokenizer = TCFG_Tokenizer.from_hf_tokenizer(tokenizer)
 
+        token_ids_to_ignore: Set[
+            int
+        ] = TCFG_tokenizer.get_special_token_ids_to_excluded()
         for token_id in range(TCFG_tokenizer.real_vocab_size()):
-            byte_repr = mapping.map(token_id)
-            trie.insert(byte_repr, token_id)
+            if token_id not in token_ids_to_ignore:
+                byte_repr = mapping.map(token_id)
+                trie.insert(byte_repr, token_id)
         trie.vocab_size = len(vocab)
         return trie
 

--- a/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
+++ b/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
@@ -39,6 +39,10 @@ class TokenizerMiddleMapping:
         ):
             return GPT2TokenizerMiddleMapping(hf_tokenizer)
         elif isinstance(hf_tokenizer, LlamaTokenizerFast):
+            # deepseek, though inheriting from LlamaTokenizerFast, is actually a GPT2TokenizerFast
+            # check https://github.com/epfl-dlab/transformers-CFG/issues/72
+            if hf_tokenizer.name_or_path.startswith("deepseek-ai/deepseek-coder"):
+                return GPT2TokenizerMiddleMapping(hf_tokenizer)
             return LLAMA1TokenizerMiddleMapping(hf_tokenizer)
         elif isinstance(hf_tokenizer, T5TokenizerFast):
             return T5TokenizerMiddleMapping(hf_tokenizer)

--- a/transformers_cfg/tokenization/tokenizer.py
+++ b/transformers_cfg/tokenization/tokenizer.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import List, Set
 from transformers import (
     GPT2TokenizerFast,
     BartTokenizerFast,
@@ -29,7 +29,7 @@ def get_TCFG_tokenizer_class(model_name_or_tokenizer):
 class TCFG_Tokenizer:
     def __init__(self, hf_tokenizer):
         self.hf_tokenizer = hf_tokenizer
-        self.special_token_ids = hf_tokenizer.all_special_ids
+        self.special_token_ids = set(hf_tokenizer.all_special_ids)
 
     def real_vocab_size(self):
         return len(self.hf_tokenizer.vocab)
@@ -67,6 +67,10 @@ class TCFG_Tokenizer:
                 f"Tokenizer not supported: {hf_tokenizer.__class__.__name__}"
             )
 
+    # will be extended by the subclasses
+    def get_special_token_ids_to_excluded(self) -> Set[int]:
+        return self.special_token_ids
+
 
 class TCFG_LlamaTokenizer(TCFG_Tokenizer):
     def __init__(self, hf_tokenizer):
@@ -77,6 +81,22 @@ class TCFG_LlamaTokenizer(TCFG_Tokenizer):
         token = re.sub(r"<0x([0-9a-fA-F]{2})>", replace_hex, token)
         # token = token.replace("▁", " ")
         return bytes(token, "utf-8")
+
+    def get_special_token_ids_to_excluded(self):
+        if self.hf_tokenizer.name_or_path.startswith("deepseek-ai/deepseek-coder"):
+            # deepseek has in total 22 special tokens, with token_ids from 32000 to 32021
+            # with first 13 being characters for bytes: {'õ': 32000, '÷': 32001, 'Á': 32002, 'ý': 32003, 'À': 32004, 'ÿ': 32005, 'ø': 32006, 'ú': 32007, 'þ': 32008, 'ü': 32009, 'ù': 32010, 'ö': 32011, 'û': 32012}
+            # the rest are special tokens for the tokenizer: { '<｜begin▁of▁sentence｜>': 32013, '<｜end▁of▁sentence｜>': 32014, '<｜fim▁hole｜>': 32015, '<｜fim▁begin｜>': 32016, '<｜fim▁end｜>': 32017, '<pad>': 32018, '<|User|>': 32019, '<|Assistant|>': 32020, '<|EOT|>': 32021}
+            added_vocab_dict = self.hf_tokenizer.get_added_vocab()
+            added_tokens_id_to_excluded = set(
+                [
+                    token_id
+                    for tok, token_id in added_vocab_dict.items()
+                    if tok.startswith("<｜")
+                ]
+            )
+            return self.special_token_ids.union(added_tokens_id_to_excluded)
+        return self.special_token_ids
 
 
 class TCFG_GPT2Tokenizer(TCFG_Tokenizer):


### PR DESCRIPTION
fix issue #72       
- Exclude special tokens in `ByteTrie` initialization.
- Handle `deepseek-ai/deepseek-coder` as `GPT2TokenizerMiddleMapping`.
- Add `get_special_token_ids_to_excluded` to `TCFG_Tokenizer` and extend in `TCFG_LlamaTokenizer` to support deepseek
- Added unit tests for `deepseek-ai/deepseek-coder-1.3b-base`.