### PR TITLE
Support for local instances of llama 3 and changes to support reusing trie and homomorphism

### DIFF
--- a/transformers_cfg/generation/logits_process.py
+++ b/transformers_cfg/generation/logits_process.py
@@ -60,12 +60,14 @@ class GrammarConstrainedLogitsProcessor(LogitsProcessor):
         return masked_logits
 
     # TODO: batching
-    def process_logits(self, input_ids, scores):
+    def process_logits(self, input_ids, scores,device=None):
         """
         :param input_ids:
         :param scores:
         :return:
         """
+        if device is None:
+            device = scores.device
         # we dynamically create stacks at the first call, so that we know the batch size and beam size
         if self.batch_parsing_states is None:
             self.batch_parsing_states = [
@@ -97,7 +99,7 @@ class GrammarConstrainedLogitsProcessor(LogitsProcessor):
         )
         logger.debug(f"input_ids: {input_ids}")
 
-        masked_scores = self.mask_logits(scores, scores.device)
+        masked_scores = self.mask_logits(scores, device)
         return masked_scores
 
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)

--- a/transformers_cfg/token_grammar_recognizer.py
+++ b/transformers_cfg/token_grammar_recognizer.py
@@ -242,6 +242,10 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
         acceptance = acceptance_matrix.reshape(len(parsing_state.stacks), -1).any(dim=0)
         return acceptance
 
+    # If running with device as a this cache will continue to fill up gpu memory
+    # this might be leaking memory when multiple instances of this object
+    # are created in the same process because the caches stay around after
+    # the object is dereferenced
     @lru_cache(maxsize=32768)
     def get_next_token_acceptance_for_single_stack(self, stack, partial_utf8, device):
         # stack = list(stack)  # needs to come in as a tuple for lru_cache

--- a/transformers_cfg/token_grammar_recognizer.py
+++ b/transformers_cfg/token_grammar_recognizer.py
@@ -16,17 +16,20 @@ logger = logging.getLogger(__name__)
 
 
 class AbsTokenRecognizer(ABC):
-    def __init__(self, grammar_str, tokenizer, start_rule_name="root", unicode=False):
+    def __init__(self, grammar_str, tokenizer, start_rule_name="root", unicode=False, trie=None):
         self.use_unicode = unicode
         self.eos_token_id = tokenizer.eos_token_id
         self.tokenizer = tokenizer
-        # parsed_grammar = parse_ebnf(grammar_str)
-        # grammar_encoding = parsed_grammar.grammar_encoding
-        # self.start_rule_id = parsed_grammar.symbol_table.get(start_rule_name)
-        # self.string_recognizer = StringRecognizer(grammar_encoding, self.start_rule_id)
-        self.byte_trie = ByteTrie.from_tokenizer(tokenizer)
+        parsed_grammar = parse_ebnf(grammar_str)
+        grammar_encoding = parsed_grammar.grammar_encoding
+        self.start_rule_id = parsed_grammar.symbol_table.get(start_rule_name)
+        self.string_recognizer = StringRecognizer(grammar_encoding, self.start_rule_id)
+        if trie is None:
+            self.byte_trie = ByteTrie.from_tokenizer(tokenizer)
+        else:
+            self.byte_trie = trie
         self.homomorphism = TokenizerMiddleMapping.from_hf_tokenizer(tokenizer)
-        self.set_grammar(grammar_str, start_rule_name)
+        # self.set_grammar(grammar_str, start_rule_name)
 
     def try_accept_token_id(self, token_id: int, parsing_state: AcceptState) -> bool:
         stacks = parsing_state.stacks
@@ -91,27 +94,22 @@ class AbsTokenRecognizer(ABC):
         """Accept a list of token IDs according to the grammar rules."""
         raise NotImplementedError
     
-    def set_grammar(self, grammar_str: str, start_rule_name: str = "root"):
-        """
-        Set the grammar of the recognizer while keeping the same tokenizer.
+    # def set_grammar(self, grammar_str: str, start_rule_name: str = "root"):
+    #     """
+    #     Set the grammar of the recognizer while keeping the same tokenizer.
         
-        Args:
-            grammar_str (str): The new grammar string in EBNF format.
-            start_rule_name (str, optional): The new start rule name. Defaults to "root".
-        """
-        parsed_grammar = parse_ebnf(grammar_str)
-        grammar_encoding = parsed_grammar.grammar_encoding
-        self.start_rule_id = parsed_grammar.symbol_table.get(start_rule_name)
-        self.string_recognizer = StringRecognizer(grammar_encoding, self.start_rule_id)
-        
-        # Reset the last_size for IncrementalTokenRecognizer
-        if hasattr(self, 'last_size'):
-            self.last_size = None
-
+    #     Args:
+    #         grammar_str (str): The new grammar string in EBNF format.
+    #         start_rule_name (str, optional): The new start rule name. Defaults to "root".
+    #     """
+    #     parsed_grammar = parse_ebnf(grammar_str)
+    #     grammar_encoding = parsed_grammar.grammar_encoding
+    #     self.start_rule_id = parsed_grammar.symbol_table.get(start_rule_name)
+    #     self.string_recognizer = StringRecognizer(grammar_encoding, self.start_rule_id)
 
 class IncrementalTokenRecognizer(AbsTokenRecognizer):
-    def __init__(self, grammar_str, start_rule_name, tokenizer, unicode=False):
-        super().__init__(grammar_str, tokenizer, start_rule_name, unicode)
+    def __init__(self, grammar_str, start_rule_name, tokenizer, unicode=False, trie=None):
+        super().__init__(grammar_str, tokenizer, start_rule_name, unicode, trie=trie)
         self.last_size = None
 
     def _update_state_with_token_id(

--- a/transformers_cfg/token_grammar_recognizer.py
+++ b/transformers_cfg/token_grammar_recognizer.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class AbsTokenRecognizer(ABC):
-    def __init__(self, grammar_str, tokenizer, start_rule_name="root", unicode=False, trie=None):
+    def __init__(self, grammar_str, tokenizer, start_rule_name="root", unicode=False, trie=None,homomorphism=None):
         self.use_unicode = unicode
         self.eos_token_id = tokenizer.eos_token_id
         self.tokenizer = tokenizer
@@ -28,7 +28,10 @@ class AbsTokenRecognizer(ABC):
             self.byte_trie = ByteTrie.from_tokenizer(tokenizer)
         else:
             self.byte_trie = trie
-        self.homomorphism = TokenizerMiddleMapping.from_hf_tokenizer(tokenizer)
+        if homomorphism is None:
+            self.homomorphism = TokenizerMiddleMapping.from_hf_tokenizer(tokenizer)
+        else:
+            self.homomorphism = homomorphism
         # self.set_grammar(grammar_str, start_rule_name)
 
     def try_accept_token_id(self, token_id: int, parsing_state: AcceptState) -> bool:
@@ -108,8 +111,8 @@ class AbsTokenRecognizer(ABC):
     #     self.string_recognizer = StringRecognizer(grammar_encoding, self.start_rule_id)
 
 class IncrementalTokenRecognizer(AbsTokenRecognizer):
-    def __init__(self, grammar_str, start_rule_name, tokenizer, unicode=False, trie=None):
-        super().__init__(grammar_str, tokenizer, start_rule_name, unicode, trie=trie)
+    def __init__(self, grammar_str, start_rule_name, tokenizer, unicode=False, trie=None,homomorphism=None):
+        super().__init__(grammar_str, tokenizer, start_rule_name, unicode, trie=trie,homomorphism=homomorphism)
         self.last_size = None
 
     def _update_state_with_token_id(

--- a/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
+++ b/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
@@ -44,7 +44,7 @@ class TokenizerMiddleMapping:
             return T5TokenizerMiddleMapping(hf_tokenizer)
         elif isinstance(
             hf_tokenizer, PreTrainedTokenizerFast
-        ) and hf_tokenizer.name_or_path.startswith("meta-llama/Meta-Llama-3"):
+        ) and 'Meta-Llama-3' in hf_tokenizer.name_or_path:
             return GPT2TokenizerMiddleMapping(hf_tokenizer)
 
     @staticmethod

--- a/transformers_cfg/tokenization/tokenizer.py
+++ b/transformers_cfg/tokenization/tokenizer.py
@@ -60,7 +60,7 @@ class TCFG_Tokenizer:
             return TCFG_PhiTokenizer(hf_tokenizer)
         elif isinstance(
             hf_tokenizer, PreTrainedTokenizerFast
-        ) and hf_tokenizer.name_or_path.startswith("meta-llama/Meta-Llama-3"):
+        ) and 'Meta-Llama-3' in hf_tokenizer.name_or_path:
             return TCFG_LlamaTokenizer(hf_tokenizer)
         else:
             raise NotImplementedError(


### PR DESCRIPTION
Here are some changes I've made for a project I'm working on. If you like any of them I can split out those changes to merge in.

1) Change the name checking for llama3 models to be looser so that local instances of the weights (specified by a path) or finetuned versions of the models can be picked up properly.

2) Support for specifying the device to use for tensors during the masking process. I needed this because the LRU cache was holding GPU memory indefinitely. I could have also just moved scores to CPU before calling the masking function or shrunk the cache size so this is non-essential. Perhaps the cache size should be customizable.

3) Added support for passing in the trie and homomorphism. In my application we have a server serving many requests and the overhead of rebuilding the trie each time is unnecessary. This allows you to reuse some of the expensive operations on initialization.