### PR TITLE
Add Support to Gemma2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 torch>=2.0.0
 numpy>=1.24.2
-transformers>=4.37.2
+transformers>=4.42.0
 tokenizers>=0.15.2
 termcolor>=2.4.0
 sentencepiece>=0.1.99
 protobuf>=4.25.2
 setuptools>=69.0.3
+datasets
 line_profiler

--- a/tests/test_accept_token_sequence/test_gemma2.py
+++ b/tests/test_accept_token_sequence/test_gemma2.py
@@ -1,0 +1,16 @@
+import unittest
+
+from transformers import AutoTokenizer
+
+from tests.test_accept_token_sequence._test_accept_tokens_mixin import (
+    TokenizerTesterMixin,
+)
+
+
+class Gemma2TokenizerTest(TokenizerTesterMixin, unittest.TestCase):
+
+    tokenizer_class = AutoTokenizer
+    pretrained_name = "google/gemma-2-2b-it"
+
+    def setUp(self):
+        super().setUp()

--- a/tests/test_metrics/test_metric.py
+++ b/tests/test_metrics/test_metric.py
@@ -1,8 +1,11 @@
 import math
 from unittest import TestCase
+
 import torch
-from transformers_cfg.metrics import ConstrainedDecodingMetric
-from transformers_cfg.metrics.metrics import ConstrainedDecodingMetricOutput
+from transformers_cfg.metrics.metrics import (
+    ConstrainedDecodingMetric,
+    ConstrainedDecodingMetricOutput,
+)
 
 
 class TestConstrainedDecodingMetric(TestCase):

--- a/transformers_cfg/tokenization/SUPPORTED_TOKENIZERS.py
+++ b/transformers_cfg/tokenization/SUPPORTED_TOKENIZERS.py
@@ -5,6 +5,7 @@ from transformers import (
     T5TokenizerFast,
     CodeGenTokenizerFast,
     PreTrainedTokenizerFast,
+    GemmaTokenizerFast
 )
 
 SUPPORTED_TOKENIZERS = {
@@ -14,4 +15,5 @@ SUPPORTED_TOKENIZERS = {
     T5TokenizerFast,
     CodeGenTokenizerFast,
     PreTrainedTokenizerFast,
+    GemmaTokenizerFast
 }

--- a/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
+++ b/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
@@ -8,6 +8,7 @@ from transformers import (
     CodeGenTokenizerFast,
     LlamaTokenizerFast,
     PreTrainedTokenizerFast,
+    GemmaTokenizerFast
 )
 
 from transformers_cfg.tokenization.utils import get_tokenizer_charset
@@ -38,7 +39,7 @@ class TokenizerMiddleMapping:
             hf_tokenizer, (GPT2TokenizerFast, BartTokenizerFast, CodeGenTokenizerFast)
         ):
             return GPT2TokenizerMiddleMapping(hf_tokenizer)
-        elif isinstance(hf_tokenizer, LlamaTokenizerFast):
+        elif isinstance(hf_tokenizer, (LlamaTokenizerFast, GemmaTokenizerFast)):
             # deepseek, though inheriting from LlamaTokenizerFast, is actually a GPT2TokenizerFast
             # check https://github.com/epfl-dlab/transformers-CFG/issues/72
             if hf_tokenizer.name_or_path.startswith("deepseek-ai/deepseek-coder"):

--- a/transformers_cfg/tokenization/tokenizer.py
+++ b/transformers_cfg/tokenization/tokenizer.py
@@ -7,6 +7,7 @@ from transformers import (
     T5TokenizerFast,
     CodeGenTokenizerFast,
     PreTrainedTokenizerFast,
+    GemmaTokenizerFast
 )
 
 from transformers_cfg.tokenization.SUPPORTED_TOKENIZERS import SUPPORTED_TOKENIZERS
@@ -53,7 +54,7 @@ class TCFG_Tokenizer:
             (GPT2TokenizerFast, BartTokenizerFast),
         ):
             return TCFG_GPT2Tokenizer(hf_tokenizer)
-        elif isinstance(hf_tokenizer, (LlamaTokenizerFast, T5TokenizerFast)):
+        elif isinstance(hf_tokenizer, (LlamaTokenizerFast, GemmaTokenizerFast, T5TokenizerFast)):
             return TCFG_LlamaTokenizer(hf_tokenizer)
         elif isinstance(hf_tokenizer, CodeGenTokenizerFast):
             # phi reuses the codegen tokenizer


### PR DESCRIPTION
This PR adds support to the `google/gemma2` model.

I've extended the code in some places to consider the Gemma tokenizer similar to the llama one. Also extended the supported tokenizers, and added a test for it, check the image bellow for the test report:

<img width="964" alt="Screenshot 2024-08-07 at 14 50 41" src="https://github.com/user-attachments/assets/3ee40673-a117-40a0-b669-d55afbd95bab">


In addition, I have fixed a couple of issues in the requirements.txt, including the bump of the transformers version to the one where the `GemmaTokenizerFast` was first introduced.

Note: the `google/gemma2` models are gated, and therefore to run the tests you need to configure the hf token locally.