### PR TITLE
Add types and MLX compatibility for cli generation

### DIFF
--- a/transformers_cfg/generation/logits_process.py
+++ b/transformers_cfg/generation/logits_process.py
@@ -2,6 +2,7 @@ import copy
 import math
 import os
 import pprint
+from typing import Optional
 
 import torch
 import logging
@@ -11,18 +12,20 @@ from transformers.generation.logits_process import (
 )
 from transformers.utils import add_start_docstrings
 
+from transformers_cfg.token_grammar_recognizer import AbsTokenRecognizer
+
 logger = logging.getLogger(__name__)
 
 
 class GrammarConstrainedLogitsProcessor(LogitsProcessor):
-    def __init__(self, grammar_constraint, valid_token_start_idx=None, device=None):
+    def __init__(self, grammar_constraint: AbsTokenRecognizer, valid_token_start_idx: Optional[int] = None, device: Optional[torch.device] = None) -> None:
         self.last_size = None
         self.grammar_constraint = grammar_constraint
         self.batch_parsing_states = None
         self.valid_token_start_idx = valid_token_start_idx
         self.device = device
 
-    def mask_logits(self, logits, device):
+    def mask_logits(self, logits: torch.FloatTensor, device: torch.device) -> torch.FloatTensor:
         masked_logits = logits.clone()
         # resolve each stack to a tensor of True/False for each token
         # indicating acceptance
@@ -77,7 +80,7 @@ class GrammarConstrainedLogitsProcessor(LogitsProcessor):
         masked_logits[~acceptance] = -math.inf
         return masked_logits
 
-    def process_logits(self, input_ids, scores):
+    def process_logits(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
         """
         :param input_ids:
         :param scores:


### PR DESCRIPTION
1. **Type Annotations**
   - Added type hints throughout the codebase
   - Improves code readability and helps developers understand the library's structure and API

2. **MLX Compatibility**
   - Integrated MLX support for faster generation
   - New CLI argument: `--use-mlx` to enable MLX acceleration
   - Note: Quantization arguments are not yet compatible with MLX (`--use_4bit` and `--use_8bit`)
   - Note: I am still waiting to be merged [on the mlx_lm repo](https://github.com/ml-explore/mlx-examples/pull/983), so the url to install mlx_lm will (maybe) change.

### Usage Example

To use MLX acceleration:

```bash
transformers-cfg-cli generate \
    -m "mlx-community/Phi-3-mini-4k-instruct-4bit" \
    -g "examples/grammars/json.ebnf" \
    -p "This is a valid json string for http request:" \
    --use_mlx \
    --max_new_tokens 60 \
    --repetition_penalty 1.1
# {"name":"John","age":30,"car":null}
```