### PR TITLE
Feature/add support for wildcard operator

### DIFF
--- a/tests/test_parsing/test_parsing.py
+++ b/tests/test_parsing/test_parsing.py
@@ -5,6 +5,7 @@ from transformers_cfg.parser import (
     parse_name,
     _parse_rhs_char_ranges,
     _parse_rhs_literal_string,
+    _parse_rhs_any_char,
     ParseState,
     parse_simple_rhs,
     END_OF_RULE_MARKER,
@@ -108,6 +109,15 @@ class Test(TestCase):
         self.assertEqual(
             "[0-9]", remaining_src, f"remaining_src: {remaining_src} != ''"
         )
+
+    def test__parse_rhs_any_char(self):
+        src = "."
+        outbuf = []
+
+        remaining_src = _parse_rhs_any_char(src, outbuf)
+        self.assertEqual(5, len(outbuf), f"len(outbuf): {len(outbuf)} != 1")
+        self.assertListEqual([4, 0, 9, 11, 255], outbuf)
+        self.assertEqual("", remaining_src, f"remaining_src: {remaining_src} != ''")
 
     def test__parse_literal_string(self):
         single_char_src = '"a"'

--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -204,6 +204,18 @@ def _parse_rhs_char_ranges(src: str, outbuf: List[int]) -> str:
     return remaining_src[1:]
 
 
+def _parse_rhs_any_char(src: str, outbuf: List[int]) -> str:
+    assert src[0] == ".", f"rule should start with '.', but got {src[0]}"
+    remaining_src = src[1:]
+    # The only symbol not allowed is '\n'
+    outbuf.append(4) # [0;ord('\n') - 1], [ord('\n') + 1;0xFF]
+    outbuf.append(0)
+    outbuf.append(ord('\n') - 1)
+    outbuf.append(ord('\n') + 1)
+    outbuf.append(0xFF)
+    return remaining_src
+
+
 def _parse_rhs_symbol_reference(src: str, state: ParseState, outbuf: List[int]) -> str:
     assert is_word_char(src[0]), f"rule should start with a word char, but got {src[0]}"
     name, remaining_src = parse_name(src)
@@ -301,6 +313,10 @@ def parse_simple_rhs(state, rhs: str, rule_name: str, outbuf, is_nested):
             # mark the start of the last symbol, for repetition operator
             last_sym_start = len(outbuf)
             remaining_rhs = _parse_rhs_char_ranges(remaining_rhs, outbuf)
+        elif remaining_rhs[0] == ".":
+            # mark the start of the last symbol, for repetition operator
+            last_sym_start = len(outbuf)
+            remaining_rhs = _parse_rhs_any_char(remaining_rhs, outbuf)
         elif is_word_char(remaining_rhs[0]):  # rule reference
             # mark the start of the last symbol, for repetition operator
             last_sym_start = len(outbuf)


### PR DESCRIPTION
This PR adds support for the wildcard operator.

The wildcard operator allow all the chars except '\n'. To do so, I allow the ranges: [0, ord('\n') - 1] U [ord('\n') + 1, max_ord].