### PR TITLE
Feature/add support for repetition brackets operator

### DIFF
--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -243,8 +243,7 @@ def _parse_rhs_repetition_operators(
         "*",
         "+",
         "?",
-        "{",
-    ), f"rule should start with '*', '+', '?' or '{{', but got {remaining_src[0]}"
+    ), f"rule should start with '*', '+', or '?', but got {remaining_src[0]}"
     out_grammar = state.grammar_encoding
     # last_sym_start = len(outbuf)
 
@@ -253,27 +252,13 @@ def _parse_rhs_repetition_operators(
     # S* --> S' ::= S S' |
     # S+ --> S' ::= S S' | S
     # S? --> S' ::= S |
-    # S{n} --> S' ::= S S S ... S (n times)
-    # S{n, m} --> S' ::= S S S ... S (n times) | S S S ... S (n + 1 times) | ... | S S S ... S (m times)
-    # S{n,} --> S' ::= S S S ... S+ (n times)
-    # S{,m} --> S' ::= S | S S | S S S | ... | S S S ... S (m times)
     sub_rule_id = generate_symbol_id(state, rule_name)
     out_grammar.append(sub_rule_id)
     sub_rule_offset = len(out_grammar)
     # placeholder for size of 1st alternate
     out_grammar.append(TO_BE_FILLED_MARKER)
     # add preceding symbol to generated rule
-    if remaining_src[0] == "{":
-        # parse the number of times the preceding symbol should be repeated
-        # we expect the number to be a single digit
-        closing_brace_idx = remaining_src.index("}")
-        num_times = int(remaining_src[1:closing_brace_idx])
-        for _ in range(num_times):
-            out_grammar.extend(outbuf[last_sym_start:])
-
-        remaining_src = remaining_src[closing_brace_idx:]
-    else:
-        out_grammar.extend(outbuf[last_sym_start:])
+    out_grammar.extend(outbuf[last_sym_start:])
     if remaining_src[0] in ("*", "+"):
         # cause generated rule to recurse
         out_grammar.append(REF_RULE_MARKER)
@@ -297,6 +282,57 @@ def _parse_rhs_repetition_operators(
     # in original rule, replace previous symbol with reference to generated rule
     outbuf[last_sym_start:] = [REF_RULE_MARKER, sub_rule_id]
     return remaining_src[1:]
+
+
+def _parse_rhs_numbered_repetition_operators(
+    remaining_src: str,
+    state: ParseState,
+    rule_name: str,
+    last_sym_start: int,
+    outbuf: List[int],
+) -> str:
+    assert remaining_src[0] == "{", f"rule should start with '{{', but got {remaining_src[0]}"
+    out_grammar = state.grammar_encoding
+
+    # parse numbers
+    closing_brace_idx = remaining_src.find("}")
+    numbers_src = remaining_src[1:closing_brace_idx]
+    n_src, m_src = numbers_src.split(",") if "," in numbers_src else (numbers_src, numbers_src) # {n} -> {n, n}
+    n = int(n_src) if n_src else 0
+    m = int(m_src) if m_src else None
+    print(f"n: {n}, m: {m}")
+
+    # rules:
+    # S{n} = S{n, n} --> S' ::= S S S ... S (n times)
+    # S{n, m} --> S' ::= S S S ... S (n times) | S S S ... S (n + 1 times) | ... | S S S ... S (m times)
+    # S{n,} --> S' ::= S S S ... S+ (n times)
+    # S{,m} = S{0, m} --> S' ::= S | S S | S S S | ... | S S S ... S (m times)
+    if not m: n -= 1 # remove the last S to replace with S+
+
+    sub_rule_id = generate_symbol_id(state, rule_name)
+    out_grammar.append(sub_rule_id)
+
+    for i in range(max(n, 1), m + 1 if m else n + 1):
+        sub_rule_offset = len(out_grammar)
+        out_grammar.append(TO_BE_FILLED_MARKER)
+        out_grammar.extend(outbuf[last_sym_start:] * i)
+        out_grammar[sub_rule_offset] = len(out_grammar) - sub_rule_offset
+        if not m:
+            out_grammar.append(REF_RULE_MARKER)
+            out_grammar.append(sub_rule_id)
+        out_grammar.append(END_OF_ALTERNATE_MARKER)
+
+    if not m:
+        sub_rule_offset = len(out_grammar)
+        out_grammar.append(TO_BE_FILLED_MARKER)
+        out_grammar.extend(outbuf[last_sym_start:])
+        out_grammar[sub_rule_offset] = len(out_grammar) - sub_rule_offset
+        out_grammar.append(END_OF_ALTERNATE_MARKER)
+
+    out_grammar.append(END_OF_RULE_MARKER)
+
+    outbuf[last_sym_start:] = [REF_RULE_MARKER, sub_rule_id]
+    return remaining_src[closing_brace_idx + 1:]
 
 
 def parse_simple_rhs(state, rhs: str, rule_name: str, outbuf, is_nested):
@@ -330,9 +366,14 @@ def parse_simple_rhs(state, rhs: str, rule_name: str, outbuf, is_nested):
                 raise RuntimeError(
                     "expecting preceeding item to */+/?/{ at " + remaining_rhs
                 )
-            remaining_rhs = _parse_rhs_repetition_operators(
-                remaining_rhs, state, rule_name, last_sym_start, outbuf
-            )
+            if remaining_rhs[0] == "{":
+                remaining_rhs = _parse_rhs_numbered_repetition_operators(
+                    remaining_rhs, state, rule_name, last_sym_start, outbuf
+                )
+            else:
+                remaining_rhs = _parse_rhs_repetition_operators(
+                    remaining_rhs, state, rule_name, last_sym_start, outbuf
+                )
         else:
             # case for newline, i.e., end of rule
             assert remaining_rhs[0] in [

--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -253,13 +253,27 @@ def _parse_rhs_repetition_operators(
     # S* --> S' ::= S S' |
     # S+ --> S' ::= S S' | S
     # S? --> S' ::= S |
+    # S{n} --> S' ::= S S S ... S (n times)
+    # S{n, m} TODO
+    # S{n,} TODO
+    # S{,m} TODO
     sub_rule_id = generate_symbol_id(state, rule_name)
     out_grammar.append(sub_rule_id)
     sub_rule_offset = len(out_grammar)
     # placeholder for size of 1st alternate
     out_grammar.append(TO_BE_FILLED_MARKER)
     # add preceding symbol to generated rule
-    out_grammar.extend(outbuf[last_sym_start:])
+    if remaining_src[0] == "{":
+        # parse the number of times the preceding symbol should be repeated
+        # we expect the number to be a single digit
+        closing_brace_idx = remaining_src.index("}")
+        num_times = int(remaining_src[1:closing_brace_idx])
+        for _ in range(num_times):
+            out_grammar.extend(outbuf[last_sym_start:])
+
+        remaining_src = remaining_src[closing_brace_idx:]
+    else:
+        out_grammar.extend(outbuf[last_sym_start:])
     if remaining_src[0] in ("*", "+"):
         # cause generated rule to recurse
         out_grammar.append(REF_RULE_MARKER)

--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -254,9 +254,9 @@ def _parse_rhs_repetition_operators(
     # S+ --> S' ::= S S' | S
     # S? --> S' ::= S |
     # S{n} --> S' ::= S S S ... S (n times)
-    # S{n, m} TODO
-    # S{n,} TODO
-    # S{,m} TODO
+    # S{n, m} --> S' ::= S S S ... S (n times) | S S S ... S (n + 1 times) | ... | S S S ... S (m times)
+    # S{n,} --> S' ::= S S S ... S+ (n times)
+    # S{,m} --> S' ::= S | S S | S S S | ... | S S S ... S (m times)
     sub_rule_id = generate_symbol_id(state, rule_name)
     out_grammar.append(sub_rule_id)
     sub_rule_offset = len(out_grammar)
@@ -328,7 +328,7 @@ def parse_simple_rhs(state, rhs: str, rule_name: str, outbuf, is_nested):
             # No need to mark the start of the last symbol, because we already did it
             if len(outbuf) - simple_rhs_offset - 1 == 0:
                 raise RuntimeError(
-                    "expecting preceeding item to */+/? at " + remaining_rhs
+                    "expecting preceeding item to */+/?/{ at " + remaining_rhs
                 )
             remaining_rhs = _parse_rhs_repetition_operators(
                 remaining_rhs, state, rule_name, last_sym_start, outbuf
@@ -411,6 +411,7 @@ def parse_ebnf(grammar_text: str) -> ParseState:
             last_grammar_repr = remaining_grammar_text
             remaining_grammar_text = parse_rule(state, remaining_grammar_text)
         state.grammar_encoding.append(END_OF_GRAMMAR_MARKER)
+        print(state.grammar_encoding)
         return state
     except RuntimeError as err:
         logger.warning("error parsing grammar:", err)

--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -300,7 +300,6 @@ def _parse_rhs_numbered_repetition_operators(
     n_src, m_src = numbers_src.split(",") if "," in numbers_src else (numbers_src, numbers_src) # {n} -> {n, n}
     n = int(n_src) if n_src else 0
     m = int(m_src) if m_src else None
-    print(f"n: {n}, m: {m}")
 
     # rules:
     # S{n} = S{n, n} --> S' ::= S S S ... S (n times)
@@ -452,7 +451,6 @@ def parse_ebnf(grammar_text: str) -> ParseState:
             last_grammar_repr = remaining_grammar_text
             remaining_grammar_text = parse_rule(state, remaining_grammar_text)
         state.grammar_encoding.append(END_OF_GRAMMAR_MARKER)
-        print(state.grammar_encoding)
         return state
     except RuntimeError as err:
         logger.warning("error parsing grammar:", err)

--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -243,7 +243,8 @@ def _parse_rhs_repetition_operators(
         "*",
         "+",
         "?",
-    ), f"rule should start with '*', '+', or '?', but got {remaining_src[0]}"
+        "{",
+    ), f"rule should start with '*', '+', '?' or '{{', but got {remaining_src[0]}"
     out_grammar = state.grammar_encoding
     # last_sym_start = len(outbuf)
 
@@ -309,7 +310,7 @@ def parse_simple_rhs(state, rhs: str, rule_name: str, outbuf, is_nested):
             # mark the start of the last symbol, for repetition operator
             last_sym_start = len(outbuf)
             remaining_rhs = _parse_rhs_grouping(remaining_rhs, state, rule_name, outbuf)
-        elif remaining_rhs[0] in ("*", "+", "?"):  # repetition operator
+        elif remaining_rhs[0] in ("*", "+", "?", "{"):  # repetition operator
             # No need to mark the start of the last symbol, because we already did it
             if len(outbuf) - simple_rhs_offset - 1 == 0:
                 raise RuntimeError(


### PR DESCRIPTION
This PR adds support for {} repetition operator #92.

The implementation supports all four standard patterns of the repetition operator:

1. Exact repetition: `"a"{10}`
2. Up to n repetitions: `"a"{,10}`
3. n or more repetitions: `"a"{10,}`
4. Range of repetitions: `"a"{10,20}`

For now I have tested this code with simple grammars, but I will add more unit-tests in the future.