### PR TITLE
Feature/add support for qwen2 models

### DIFF
--- a/transformers_cfg/tokenization/SUPPORTED_TOKENIZERS.py
+++ b/transformers_cfg/tokenization/SUPPORTED_TOKENIZERS.py
@@ -5,7 +5,8 @@ from transformers import (
     T5TokenizerFast,
     CodeGenTokenizerFast,
     PreTrainedTokenizerFast,
-    GemmaTokenizerFast
+    GemmaTokenizerFast,
+    Qwen2TokenizerFast
 )
 
 SUPPORTED_TOKENIZERS = {
@@ -15,5 +16,6 @@ SUPPORTED_TOKENIZERS = {
     T5TokenizerFast,
     CodeGenTokenizerFast,
     PreTrainedTokenizerFast,
-    GemmaTokenizerFast
+    GemmaTokenizerFast,
+    Qwen2TokenizerFast
 }

--- a/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
+++ b/transformers_cfg/tokenization/middle/TokenizerMiddleMapping.py
@@ -8,7 +8,8 @@ from transformers import (
     CodeGenTokenizerFast,
     LlamaTokenizerFast,
     PreTrainedTokenizerFast,
-    GemmaTokenizerFast
+    GemmaTokenizerFast,
+    Qwen2TokenizerFast
 )
 
 from transformers_cfg.tokenization.utils import get_tokenizer_charset
@@ -36,7 +37,7 @@ class TokenizerMiddleMapping:
             type(hf_tokenizer) in SUPPORTED_TOKENIZERS
         ), f"Tokenizer not supported: {hf_tokenizer.__class__.__name__}, supported tokenizers: {SUPPORTED_TOKENIZERS}"
         if isinstance(
-            hf_tokenizer, (GPT2TokenizerFast, BartTokenizerFast, CodeGenTokenizerFast)
+            hf_tokenizer, (GPT2TokenizerFast, BartTokenizerFast, CodeGenTokenizerFast, Qwen2TokenizerFast)
         ):
             return GPT2TokenizerMiddleMapping(hf_tokenizer)
         elif isinstance(hf_tokenizer, (LlamaTokenizerFast, GemmaTokenizerFast)):

--- a/transformers_cfg/tokenization/tokenizer.py
+++ b/transformers_cfg/tokenization/tokenizer.py
@@ -7,7 +7,8 @@ from transformers import (
     T5TokenizerFast,
     CodeGenTokenizerFast,
     PreTrainedTokenizerFast,
-    GemmaTokenizerFast
+    GemmaTokenizerFast,
+    Qwen2TokenizerFast
 )
 
 from transformers_cfg.tokenization.SUPPORTED_TOKENIZERS import SUPPORTED_TOKENIZERS
@@ -51,7 +52,7 @@ class TCFG_Tokenizer:
 
         if isinstance(
             hf_tokenizer,
-            (GPT2TokenizerFast, BartTokenizerFast),
+            (GPT2TokenizerFast, BartTokenizerFast, Qwen2TokenizerFast),
         ):
             return TCFG_GPT2Tokenizer(hf_tokenizer)
         elif isinstance(hf_tokenizer, (LlamaTokenizerFast, GemmaTokenizerFast, T5TokenizerFast)):


### PR DESCRIPTION
This PR introduces support for the Qwen2TokenizerFast tokenizer, enabling the use of all Qwen2 and Qwen2.5 models.

I found that Qwen2TokenizerFast is the same tokenizer as the GPT2TokenizerFast. Therefore, I routed the Qwen2 tokenizer to the GPT2 tokenizer for compatibility [source](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2/tokenization_qwen2_fast.py).