### PR TITLE
Reuse the same GrammarConstrainedLogitsProcessor across generations

### DIFF
--- a/transformers_cfg/generation/logits_process.py
+++ b/transformers_cfg/generation/logits_process.py
@@ -12,6 +12,7 @@ from transformers.generation.logits_process import (
 )
 from transformers.utils import add_start_docstrings
 
+from transformers_cfg.grammar_utils import IncrementalGrammarConstraint
 from transformers_cfg.token_grammar_recognizer import AbsTokenRecognizer
 
 logger = logging.getLogger(__name__)
@@ -127,3 +128,8 @@ class GrammarConstrainedLogitsProcessor(LogitsProcessor):
         self, input_ids: torch.LongTensor, scores: torch.FloatTensor
     ) -> torch.FloatTensor:
         return self.process_logits(input_ids, scores)
+    
+    def reset(self):
+        self.batch_parsing_states = None
+        if isinstance(self.grammar_constraint, IncrementalGrammarConstraint):
+            self.grammar_constraint.reset()

--- a/transformers_cfg/token_grammar_recognizer.py
+++ b/transformers_cfg/token_grammar_recognizer.py
@@ -285,6 +285,9 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
         x = torch.tensor(token_acceptance, dtype=torch.bool, device=device)
         x_eos = self.validate_and_set_eos_acceptance(x)
         return x_eos
+    
+    def reset(self):
+        self.last_size = None
 
 
 # def check_token_acceptance_in_trie(trie, stacks, grammar, eos_token_id, accepts):


### PR DESCRIPTION
This PR adds support for reusing a single instance of `GrammarConstrainedLogitsProcessor` as requested in #49.
This is possible with the simple addition of a `reset` method.