### PR TITLE
Enhancement: avoid computing full mask (+ adding types)

### DIFF
--- a/transformers_cfg/generation/logits_process.py
+++ b/transformers_cfg/generation/logits_process.py
@@ -2,7 +2,7 @@ import copy
 import math
 import os
 import pprint
-from typing import Optional
+from typing import Optional, Literal
 
 import torch
 import logging
@@ -18,32 +18,37 @@ logger = logging.getLogger(__name__)
 
 
 class GrammarConstrainedLogitsProcessor(LogitsProcessor):
-    def __init__(self, grammar_constraint: AbsTokenRecognizer, valid_token_start_idx: Optional[int] = None, device: Optional[torch.device] = None) -> None:
+    def __init__(self, grammar_constraint: AbsTokenRecognizer, valid_token_start_idx: Optional[int] = None, execution_mode: Literal["speculation", "full_mask"] = "speculation", device: Optional[torch.device] = None) -> None:
         self.last_size = None
         self.grammar_constraint = grammar_constraint
         self.batch_parsing_states = None
         self.valid_token_start_idx = valid_token_start_idx
+        self.execution_mode = execution_mode
         self.device = device
 
     def mask_logits(self, logits: torch.FloatTensor, device: torch.device) -> torch.FloatTensor:
         masked_logits = logits.clone()
-        # try to accept the most likely token
-        acceptance = torch.zeros((logits.shape[0], len(self.grammar_constraint.homomorphism)), dtype=torch.bool, device=device)
-        next_tokens = torch.argmax(logits, dim=-1)
-        for i, next_token in enumerate(next_tokens.tolist()):
-            try:
-                is_next_token_accepted = self.grammar_constraint.accept_token_ids([next_token], self.batch_parsing_states[i])
-            except ValueError:
-                is_next_token_accepted = False
-            if is_next_token_accepted:
-                acceptance[i, next_token] = True
-            else:
-                # resolve each stack to a tensor of True/False for each token
-                # indicating acceptance
-                # acceptance = self.grammar_acceptor.filter_vocab(self.stacks, device)
-                acceptance[i] = self.grammar_constraint.filter_vocab(
-                    self.batch_parsing_states[i], device
-                )
+        
+        if self.execution_mode == "speculation":
+            # try to accept the most likely token
+            acceptance = torch.zeros((logits.shape[0], len(self.grammar_constraint.homomorphism)), dtype=torch.bool, device=device)
+            next_tokens = torch.argmax(logits, dim=-1)
+            for i, next_token in enumerate(next_tokens.tolist()):
+                try:
+                    is_next_token_accepted = self.grammar_constraint.accept_token_ids([next_token], self.batch_parsing_states[i])
+                except ValueError:
+                    is_next_token_accepted = False
+                if is_next_token_accepted:
+                    acceptance[i, next_token] = True
+                else:
+                    # resolve each stack to a tensor of True/False for each token
+                    # indicating acceptance
+                    # acceptance = self.grammar_acceptor.filter_vocab(self.stacks, device)
+                    acceptance[i] = self.grammar_constraint.filter_vocab(
+                        self.batch_parsing_states[i], device
+                    )
+        else:
+            acceptance = self.grammar_constraint.batch_filter_vocab(self.batch_parsing_states, device)
 
         # if the logits size of the model is more than the tokennizer vocab
         # we artificially expand the acceptance tensor and block everything

--- a/transformers_cfg/generation/logits_process.py
+++ b/transformers_cfg/generation/logits_process.py
@@ -30,9 +30,9 @@ class GrammarConstrainedLogitsProcessor(LogitsProcessor):
         # try to accept the most likely token
         acceptance = torch.zeros((logits.shape[0], len(self.grammar_constraint.homomorphism)), dtype=torch.bool, device=device)
         next_tokens = torch.argmax(logits, dim=-1)
-        for i, next_token in enumerate(next_tokens):
+        for i, next_token in enumerate(next_tokens.tolist()):
             try:
-                is_next_token_accepted = self.grammar_constraint.accept_token_ids([next_token.item()], self.batch_parsing_states[i])
+                is_next_token_accepted = self.grammar_constraint.accept_token_ids([next_token], self.batch_parsing_states[i])
             except ValueError:
                 is_next_token_accepted = False
             if is_next_token_accepted:

--- a/transformers_cfg/recognizer.py
+++ b/transformers_cfg/recognizer.py
@@ -14,7 +14,7 @@ import logging
 
 
 class AcceptState:
-    def __init__(self, stacks, partial_utf8):
+    def __init__(self, stacks: Set[Tuple[int]], partial_utf8: PartialUTF8):
         self.stacks = stacks
         self.partial_utf8 = partial_utf8
 

--- a/transformers_cfg/token_grammar_recognizer.py
+++ b/transformers_cfg/token_grammar_recognizer.py
@@ -101,7 +101,7 @@ class AbsTokenRecognizer(ABC):
             acceptance[self.eos_token_id] = False
         return acceptance
 
-    def accept_token_ids(self, token_ids, stacks) -> bool:
+    def accept_token_ids(self, token_ids: List[int], parsing_state: Optional[AcceptState] = None, as_string: bool = True) -> bool:
         """Accept a list of token IDs according to the grammar rules."""
         raise NotImplementedError
 
@@ -219,7 +219,7 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
         self,
         token_ids: List[int],
         parsing_state: Optional[AcceptState] = None,
-        as_string=True,
+        as_string: bool = True,
     ):
         if parsing_state is None:
             parsing_state = self.string_recognizer.get_initial_parsing_state()
@@ -240,12 +240,11 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
                     logging.debug(f"The decoded string is {decoded_string}")
         return parsing_state
 
-    # TODO: remove this method or clarify its arguments (it is not used anywhere)
-    def accept_token_ids(self, token_ids, stacks=None, as_string=True) -> bool:
+    def accept_token_ids(self, token_ids: List[int], parsing_state: Optional[AcceptState] = None, as_string: bool = True) -> bool:
         output_state = self._update_state_with_single_token_seq(
-            token_ids, stacks, as_string
+            token_ids, parsing_state, as_string
         ).stacks
-        return True if output_state else False
+        return bool(output_state)
 
     def get_next_token_acceptance(self, parsing_state: AcceptState, device: torch.device) -> torch.Tensor:
         acceptance_matrix = torch.cat(
@@ -328,7 +327,7 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
 #     return accepts
 
 
-def check_token_acceptance_in_trie(trie_node: TrieNode, stacks: List[Tuple[int]], recognizer: StringRecognizer, eos_token_id: int, accepts: List[bool]):
+def check_token_acceptance_in_trie(trie_node: TrieNode, stacks: List[Tuple[int]], recognizer: StringRecognizer, eos_token_id: int, accepts: List[bool]) -> List[bool]:
     if trie_node.is_end_of_word:
         token_id = trie_node.token_id
         if token_id != eos_token_id:

--- a/transformers_cfg/token_grammar_recognizer.py
+++ b/transformers_cfg/token_grammar_recognizer.py
@@ -243,11 +243,11 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
     def accept_token_ids(self, token_ids: List[int], parsing_state: Optional[AcceptState] = None, as_string: bool = True) -> bool:
         output_state = self._update_state_with_single_token_seq(
             token_ids, parsing_state, as_string
-        ).stacks
-        return bool(output_state)
+        )
+        return len(output_state.stacks) > 0
 
     def get_next_token_acceptance(self, parsing_state: AcceptState, device: torch.device) -> torch.Tensor:
-        acceptance_matrix = torch.cat(
+        acceptance_matrix = torch.stack(
             [
                 self.get_next_token_acceptance_for_single_stack(
                     tuple(stack), parsing_state.partial_utf8, device
@@ -256,7 +256,7 @@ class IncrementalTokenRecognizer(AbsTokenRecognizer):
             ]
         )
         # Merge stacks: any True => True
-        acceptance = acceptance_matrix.reshape(len(parsing_state.stacks), -1).any(dim=0)
+        acceptance = acceptance_matrix.any(dim=0)
         return acceptance
 
     # If running on a GPU device this cache can continue to fill up GPU memory


### PR DESCRIPTION
While running a generation using the CLI on the student JSON grammar with the Phi-3.5-mini-4bit model, I observed that the majority of tokens were already valid without applying a mask.

![Token Generation Screenshot](https://github.com/user-attachments/assets/8c1f5606-41e5-4546-ae4c-08e8f2d720b2)

As evident in the screenshot above, the green tokens were sampled without constraints and were already valid.

I implemented the following logic in the `mask_logits` method:
1. Compute the argmax of the logits to determine the sampled token (with temperature set to 0). This operation has negligible computational cost (approximately 1e-5 seconds).
2. Evaluate the validity of this token.
3. If valid, return this token directly.
4. If invalid, compute the entire mask.

This minor modification resulted in a significant speed increase of 3 tokens per second.

![Optimized Token Generation](https://github.com/user-attachments/assets/635ab844-943a-48ed-9907-c0cd887f1a7d)

As shown in the second screenshot, the impact of the `logits_processor` has been substantially reduced. It's worth noting that this improvement becomes more pronounced as the vocabulary size increases.