### PR TITLE
Fix Error Caused by Using Repetition Brackets

### DIFF
--- a/transformers_cfg/parser.py
+++ b/transformers_cfg/parser.py
@@ -486,7 +486,7 @@ def _parse_rhs_numbered_repetition_operators(
         sub_rule.add_alternative(sub_rule_alternative)
         sub_rule_alternative.add_symbol(alternative.symbols[-1])
 
-    state.grammar_rules.append(sub_rule)
+    state.grammar_rules[sub_rule_id] = sub_rule
     alternative.symbols[-1] = [ReferenceElement(sub_rule_id)]
     return remaining_src[closing_brace_idx + 1:]
 


### PR DESCRIPTION
The issue with the current implementation is that grammar_rules is a dictionary, which inherently does not support the append method. As a result, attempting to use repetition brackets (#96) in a grammar leads to the following error:

```
File transformers_cfg/parser.py:489, in _parse_rhs_numbered_repetition_operators(remaining_src, state, rule_name, alternative)
--> 489 state.grammar_rules.append(sub_rule)
    
AttributeError: 'dict' object has no attribute 'append'
```

The `sub_rule` is now added as a key-value pair, using the `sub_rule_id` as the key.